### PR TITLE
Fix link to hopr-chat releases

### DIFF
--- a/getting-started/hopr-chat/quickstart.md
+++ b/getting-started/hopr-chat/quickstart.md
@@ -123,7 +123,7 @@ Download the latest version of **HOPR Chat** by clicking in the following link.
 {% endtabs %}
 
 {% hint style="info" %}
-You can see all our releases in our GitHub [releases](https://github.com/hoprnet/hopr-core/releases) page.
+You can see all our releases in our GitHub [releases](https://github.com/hoprnet/hopr-chat/releases) page.
 {% endhint %}
 
 ### Extracting HOPR Chat


### PR DESCRIPTION
Fix link to hopr-chat releases in the quickstart docs